### PR TITLE
Proto to grpc comments propagation

### DIFF
--- a/rejoiner/pom.xml
+++ b/rejoiner/pom.xml
@@ -37,7 +37,7 @@
   <groupId>com.zaplabs</groupId>
   <artifactId>rejoiner</artifactId>
   <name>Rejoiner</name>
-  <version>0.1.2</version>
+  <version>0.2.0</version>
   <description>Generating GraphQL schemas from Protobufs.</description>
   <url>https://github.com/google/rejoiner</url>
   <packaging>jar</packaging>

--- a/rejoiner/pom.xml
+++ b/rejoiner/pom.xml
@@ -258,6 +258,11 @@
        <version>0.5.1</version>
        <configuration>
          <protocExecutable>/usr/local/bin/protoc</protocExecutable>
+         <writeDescriptorSet>true</writeDescriptorSet>
+         <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
+         <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto</descriptorSetOutputDirectory>
+         <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
+         <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
        </configuration>
        <executions>
          <execution>

--- a/rejoiner/pom.xml
+++ b/rejoiner/pom.xml
@@ -37,7 +37,7 @@
   <groupId>com.zaplabs</groupId>
   <artifactId>rejoiner</artifactId>
   <name>Rejoiner</name>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <description>Generating GraphQL schemas from Protobufs.</description>
   <url>https://github.com/google/rejoiner</url>
   <packaging>jar</packaging>

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
@@ -52,8 +52,8 @@ class DescriptorSet {
   }
 
   private static String constructComment(DescriptorProtos.SourceCodeInfo.Location location) {
-    String trailingComment = location.getTrailingComments();
-    return (location.getLeadingComments()
+    String trailingComment = location.getTrailingComments().trim();
+    return (location.getLeadingComments().trim()
         + (!trailingComment.isEmpty() ? (". " + trailingComment) : "")
     ).replaceAll("^[*\\\\/.]*\\s*", "");
   }
@@ -67,7 +67,7 @@ class DescriptorSet {
    * @see DescriptorProtos.SourceCodeInfoOrBuilder for more info
    *
    * @param descriptor proto file descriptor
-   * @param path pathe of the element
+   * @param path       path of the element
    * @return full element's path as a string
    */
   private static Optional<String> getFullName(DescriptorProtos.FileDescriptorProto descriptor, List<Integer> path) {

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/DescriptorSet.java
@@ -1,0 +1,132 @@
+package com.google.api.graphql.rejoiner;
+
+import com.google.protobuf.DescriptorProtos;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class DescriptorSet {
+  private static final String DEFAULT_DESCRIPTOR_SET_FILE_LOCATION = "META-INF/proto/descriptor_set.desc";
+
+  static final Map<String, String> COMMENTS = getCommentsFromDescriptorFile();
+
+  private DescriptorSet() {
+  }
+
+  private static Map<String, String> getCommentsFromDescriptorFile() {
+
+    try {
+      InputStream is = DescriptorSet.class.getClassLoader().getResourceAsStream(DEFAULT_DESCRIPTOR_SET_FILE_LOCATION);
+      DescriptorProtos.FileDescriptorSet descriptors = DescriptorProtos.FileDescriptorSet.parseFrom(is);
+      return descriptors
+          .getFileList()
+          .stream()
+          .flatMap(fileDescriptorProto -> parseDescriptorFile(fileDescriptorProto)
+              .entrySet()
+              .stream()
+          )
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (entry, value) -> entry));
+    } catch (IOException ignored) {
+    }
+    return Collections.emptyMap();
+  }
+
+  private static Map<String, String> parseDescriptorFile(DescriptorProtos.FileDescriptorProto descriptor) {
+    return descriptor
+        .getSourceCodeInfo()
+        .getLocationList()
+        .stream()
+        .filter(location -> !(location.getLeadingComments().isEmpty() && location.getTrailingComments().isEmpty()))
+        .map(location -> getFullName(descriptor, location.getPathList())
+            .map(fullName -> new AbstractMap.SimpleImmutableEntry<>(fullName, constructComment(location)))
+        )
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private static String constructComment(DescriptorProtos.SourceCodeInfo.Location location) {
+    String trailingComment = location.getTrailingComments();
+    return (location.getLeadingComments()
+        + (!trailingComment.isEmpty() ? (". " + trailingComment) : "")
+    ).replaceAll("^[*\\\\/.]*\\s*", "");
+  }
+
+  /**
+   * Iterate through a component's path inside a protobufer descriptor.
+   * The path is a tuple of component type and a relative position
+   * For example:
+   * [4, 1, 3, 2, 2, 1] or [MESSAGE_TYPE_FIELD_NUMBER, 1, NESTED_TYPE_FIELD_NUMBER, 2, FIELD_FIELD_NUMBER, 1]
+   * is representing the second field of the third nested message in the second message in the file
+   * @see DescriptorProtos.SourceCodeInfoOrBuilder for more info
+   *
+   * @param descriptor proto file descriptor
+   * @param path pathe of the element
+   * @return full element's path as a string
+   */
+  private static Optional<String> getFullName(DescriptorProtos.FileDescriptorProto descriptor, List<Integer> path) {
+    String fullName = descriptor.getPackage();
+    switch (path.get(0)) {
+      case DescriptorProtos.FileDescriptorProto.ENUM_TYPE_FIELD_NUMBER:
+        DescriptorProtos.EnumDescriptorProto enumDescriptor = descriptor.getEnumType(path.get(1));
+        return Optional.of(appendEnumToFullName(enumDescriptor, path, fullName));
+      case DescriptorProtos.FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER:
+        DescriptorProtos.DescriptorProto message = descriptor.getMessageType(path.get(1));
+        return appendMessageToFullName(message, path, fullName);
+      case DescriptorProtos.FileDescriptorProto.SERVICE_FIELD_NUMBER:
+        DescriptorProtos.ServiceDescriptorProto serviceDescriptor = descriptor.getService(path.get(1));
+        fullName += appendNameComponent(serviceDescriptor.getName());
+        if (path.size() > 2) {
+          fullName += appendNameComponent(serviceDescriptor.getMethod(path.get(3)).getName());
+        }
+        return Optional.of(fullName);
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static Optional<String> appendMessageToFullName(
+      DescriptorProtos.DescriptorProto message, List<Integer> path, String fullName) {
+    fullName += appendNameComponent(message.getName());
+    return path.size() > 2 ?
+        appendToFullName(message, path.subList(2, path.size()), fullName)
+        : Optional.of(fullName);
+  }
+
+  private static Optional<String> appendToFullName(
+      DescriptorProtos.DescriptorProto messageDescriptor, List<Integer> path, String fullName) {
+    switch (path.get(0)) {
+      case DescriptorProtos.DescriptorProto.NESTED_TYPE_FIELD_NUMBER:
+        DescriptorProtos.DescriptorProto nestedMessage = messageDescriptor.getNestedType(path.get(1));
+        return appendMessageToFullName(nestedMessage, path, fullName);
+      case DescriptorProtos.DescriptorProto.ENUM_TYPE_FIELD_NUMBER:
+        DescriptorProtos.EnumDescriptorProto enumDescriptor = messageDescriptor.getEnumType(path.get(1));
+        return Optional.of(appendEnumToFullName(enumDescriptor, path, fullName));
+      case DescriptorProtos.DescriptorProto.FIELD_FIELD_NUMBER:
+        DescriptorProtos.FieldDescriptorProto fieldDescriptor = messageDescriptor.getField(path.get(1));
+        return Optional.of(fullName + appendNameComponent(fieldDescriptor.getName()));
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static String appendEnumToFullName(
+      DescriptorProtos.EnumDescriptorProto enumDescriptor, List<Integer> path, String fullName) {
+    fullName += appendNameComponent(enumDescriptor.getName());
+    if (path.size() > 2) {
+      fullName += appendNameComponent(enumDescriptor.getValue(path.get(3)).getName());
+    }
+    return fullName;
+  }
+
+  private static String appendNameComponent(String component) {
+    return "." + component;
+  }
+
+}

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/GqlInputConverter.java
@@ -14,9 +14,6 @@
 
 package com.google.api.graphql.rejoiner;
 
-import static graphql.Scalars.GraphQLString;
-import com.google.common.base.CaseFormat;
-import com.google.common.base.Converter;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -26,6 +23,14 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.GenericDescriptor;
 import com.google.protobuf.Message;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
@@ -33,12 +38,8 @@ import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import static graphql.Scalars.GraphQLString;
 
 /**
  * Converts GraphQL inputs into Protobuf message.
@@ -111,8 +112,11 @@ final class GqlInputConverter {
         inputBuilder.type((GraphQLInputType) fieldType);
       }
 
+      inputBuilder.description(DescriptorSet.COMMENTS.get(field.getFullName()));
+
       builder.field(inputBuilder.build());
     }
+    builder.description(DescriptorSet.COMMENTS.get(descriptor.getFullName()));
     return builder.build();
   }
 
@@ -171,7 +175,9 @@ final class GqlInputConverter {
 
   // Based on ProtoRegistry.Builder, but builds a map of descriptors rather than types.
 
-  /** Builder for GqlInputConverter. */
+  /**
+   * Builder for GqlInputConverter.
+   */
   static class Builder {
     private final ArrayList<FileDescriptor> fileDescriptors = new ArrayList<>();
     private final ArrayList<Descriptor> descriptors = new ArrayList<>();

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Mutation.java
@@ -22,4 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Mutation {
   /** Name of the Mutation, only used when annotating a method. */
   String value() default "";
+  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  String fullName() default "";
 }

--- a/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
+++ b/rejoiner/src/main/java/com/google/api/graphql/rejoiner/Query.java
@@ -23,4 +23,7 @@ public @interface Query {
 
   /** Name of the Query, only used when annotating a method. */
   String value() default "";
+  /** Full service name (including package) to be able to find appropriate metadata in generated descriptor set. */
+  String fullName() default "";
+
 }

--- a/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
+++ b/rejoiner/src/test/java/com/google/api/graphql/rejoiner/ProtoToGqlTest.java
@@ -22,6 +22,7 @@ import com.google.api.graphql.rejoiner.TestProto.Proto2;
 import com.google.api.graphql.rejoiner.TestProto.Proto2.TestEnum;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
+import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,4 +78,28 @@ public final class ProtoToGqlTest {
     assertThat(result.getFieldDefinition("intField")).isNotNull();
     assertThat(result.getFieldDefinition("camelCaseName")).isNotNull();
   }
+
+  @Test
+  public void checkComments() {
+    GraphQLObjectType result = ProtoToGql.convert(Proto1.getDescriptor(), null);
+
+    GraphQLFieldDefinition intFieldGraphQLFieldDefinition = result.getFieldDefinition("intField");
+    assertThat(intFieldGraphQLFieldDefinition).isNotNull();
+    assertThat(intFieldGraphQLFieldDefinition.getDescription().equals("Some leading comment. Some trailing comment")).isTrue();
+
+    GraphQLFieldDefinition camelCaseNameGraphQLFieldDefinition = result.getFieldDefinition("camelCaseName");
+    assertThat(camelCaseNameGraphQLFieldDefinition).isNotNull();
+    assertThat(camelCaseNameGraphQLFieldDefinition.getDescription().equals("Some leading comment")).isTrue();
+
+    GraphQLFieldDefinition testProtoNameGraphQLFieldDefinition = result.getFieldDefinition("testProto");
+    assertThat(testProtoNameGraphQLFieldDefinition).isNotNull();
+    assertThat(testProtoNameGraphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+
+
+    GraphQLEnumType enumType = ProtoToGql.convert(TestEnum.getDescriptor());
+
+    GraphQLEnumValueDefinition graphQLFieldDefinition = enumType.getValue("UNKNOWN");
+    assertThat(graphQLFieldDefinition.getDescription().equals("Some trailing comment")).isTrue();
+  }
+
 }

--- a/rejoiner/src/test/proto/test_proto.proto
+++ b/rejoiner/src/test/proto/test_proto.proto
@@ -20,9 +20,11 @@ option java_package = "com.google.api.graphql.rejoiner";
 
 message Proto1 {
   string id = 1;
-  int64 int_field = 2;
-  Proto2 test_proto = 3;
+  //Some leading comment
+  int64 int_field = 2;//Some trailing comment
+  Proto2 test_proto = 3;//Some trailing comment
   InnerProto test_inner_proto = 4;
+  //Some leading comment
   int64 camelCaseName = 5;
   string name_field = 6 [json_name="RenamedField"];
 
@@ -35,8 +37,9 @@ message Proto2 {
   string inner_id = 1;
   repeated TestEnum enums = 2;
 
+  //Enum comment
   enum TestEnum {
-    UNKNOWN = 0;
+    UNKNOWN = 0; //Some trailing comment
     FOO = 1;
     BAR = 2;
   }


### PR DESCRIPTION
I'm proposing to use standard protobuf description set file as a source of comments in order to propagate comments from proto to GraphQL schema

The proto description set file could be generated by protobuf plugin:

Maven:
```
   <plugin>
       <groupId>org.xolstice.maven.plugins</groupId>
       <artifactId>protobuf-maven-plugin</artifactId>
       <version>0.5.1</version>
       <configuration>
         <protocExecutable>/usr/local/bin/protoc</protocExecutable>
         <writeDescriptorSet>true</writeDescriptorSet>
         <descriptorSetFileName>descriptor_set.desc</descriptorSetFileName>
         <descriptorSetOutputDirectory>${build.directory}/test-classes/META-INF/proto</descriptorSetOutputDirectory>
         <includeSourceInfoInDescriptorSet>true</includeSourceInfoInDescriptorSet>
         <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
       </configuration>
       <executions>
         <execution>
           <goals>
             <goal>compile</goal>
             <goal>test-compile</goal>
           </goals>
         </execution>
       </executions>
    </plugin>
```

Grails:
```
protobuf {
    protoc { artifact = "com.google.protobuf:protoc:${protocVersion}" }
    plugins {
        grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" }
    }
    generateProtoTasks {
        ofSourceSet('main').each{task ->
            task.generateDescriptorSet = true
            task.descriptorSetOptions.includeImports = true
            task.descriptorSetOptions.includeSourceInfo = true
            task.descriptorSetOptions.path = "${buildDir}/resources/main/META-INF/proto/descriptor_set.desc"
            task.plugins {
                grpc {}
            }
        }
    }
}
```

The generated protofile description file must be named as `descriptor_set.desc` and located in `META-INF/proto` of the final jar file